### PR TITLE
Update Travis CI badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AlienVault
 
-[![Build Status](https://travis-ci.org/form3tech-oss/alienvault.svg?branch=master)](https://travis-ci.org/form3tech-oss/alienvault)
+[![Build Status](https://travis-ci.com/form3tech-oss/alienvault.svg?branch=master)](https://travis-ci.com/form3tech-oss/alienvault)
 
 A basic Go package providing a client for the AlienVault API.
 


### PR DESCRIPTION
This repo has been migrated from https://travis-ci.org to https://travis-ci.com.